### PR TITLE
Renamed size to inputSize

### DIFF
--- a/app/components/ui-number-array-input.js
+++ b/app/components/ui-number-array-input.js
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
 	elements: null, // the number of elements in the array
 	placeholder: null,
 	align: 'left',
-	size: null,
+	inputSize: null,
 	min: null,
 	max: null,
 	correctionRules: null,
@@ -33,8 +33,8 @@ export default Ember.Component.extend({
 	showSum: false,
 	// observers and event handlers
 	// ----------------------------
-	// on initialisation ensure element count is defaulted to 
-	// the value's array length (if not already specified)	
+	// on initialisation ensure element count is defaulted to
+	// the value's array length (if not already specified)
 	_elementsInit: function() {
 		var value = this.get('value');
 		var elements = this.get('elements');
@@ -53,19 +53,19 @@ export default Ember.Component.extend({
 			for(var i=0; i < elements; i++) {
 				// ensure value always has full array length
 				if(i >= value.length) {
-					value[i] = null; 
+					value[i] = null;
 				}
 				// assign base name/value pair
 				arrayElements[i] = Ember.Object.create({ id: i, value: value[i] ? Number(value[i]) : null });
 				// add appropriate ornamentation
-				var o = this.getProperties('placeholder','min','max','align', 'size', 'correctionRules','status','statusVisualize');
+				var o = this.getProperties('placeholder','min','max','align', 'inputSize', 'correctionRules','status','statusVisualize');
 				var alwaysArrayProps = ['correctionRules'];
 				for (var property in o) {
 					// if always an "array"
 					if (alwaysArrayProps.contains(property) && o[property]) {
 						o[property] = o[property].split(',');
 					}
-					// split comma-seperated list 
+					// split comma-seperated list
 					if (typeOf(o[property]) === 'string' && o[property].indexOf(',') !== -1) {
 						o[property] = o[property].split(',');
 					}
@@ -81,7 +81,7 @@ export default Ember.Component.extend({
 			}
 			this.set('arrayElements',arrayElements);
 		});
-	}.observes('elements','placeholder','align','min','max','size','correctionRules','status','statusVisualize').on('didInsertElement'),
+	}.observes('elements','placeholder','align','min','max','inputSize','correctionRules','status','statusVisualize').on('didInsertElement'),
 	_arrayElementDidChange: function() {
 		run.next(this, function() {
 			var elements = this.get('arrayElements');
@@ -120,7 +120,7 @@ export default Ember.Component.extend({
 			var midPoint = Math.floor(sampleSize / 2);
 			if (sampleSize % 2 === 0 && sampleSize !== 0) {
 				median = (samples[midPoint] + samples[midPoint - 1]) / 2;
-				
+
 			} else if (sampleSize !== 0) {
 				median = samples[midPoint];
 			} else {

--- a/app/components/ui-number-input.js
+++ b/app/components/ui-number-input.js
@@ -17,9 +17,9 @@ export default Ember.TextField.extend(InputStatusMixin,InputCorrectionMixin,UiEv
 	bsFormControl: function() {
 		return this.get('bs') ? 'form-control' : false;
 	}.property('bs'),
-	size: 'default',
+	inputSize: 'default',
 	sizeClass: function() {
-		var size = this.get('size');
+		var size = this.get('inputSize');
 		if(['lg','large'].contains(size)) {
 			return 'input-lg';
 		} else if(['sm','small'].contains(size)) {
@@ -27,7 +27,7 @@ export default Ember.TextField.extend(InputStatusMixin,InputCorrectionMixin,UiEv
 		} else {
 			return false;
 		}
-	}.property('size'),
+	}.property('inputSize'),
 	min: null,
 	max: null,
 	step: null,
@@ -47,14 +47,14 @@ export default Ember.TextField.extend(InputStatusMixin,InputCorrectionMixin,UiEv
 		return this.processCorrections('keyDown',evt);
 	},
 	// MIXIN CONFIG
-	defaultCorrectionRules: ['numericOnly'], 
+	defaultCorrectionRules: ['numericOnly'],
 	emphasize: function(animationType) {
 		// this.set('animationClass', animationType);
 		var self = this;
 		if (!isEmpty(animationType)) {
 			this.$().addClass('%@ animated'.fmt(animationType)).one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
 				self.$().removeClass('%@ animated'.fmt(animationType));
-			});			
+			});
 		}
 	},
 	// VISUAL STYLE
@@ -84,7 +84,7 @@ export default Ember.TextField.extend(InputStatusMixin,InputCorrectionMixin,UiEv
 	// MESSAGE QUEUEING
 	messageQueue: [],
 	/**
-	 * Adds messages to queue. Queue items can be dismissed explictly or can timeout 
+	 * Adds messages to queue. Queue items can be dismissed explictly or can timeout
 	 * if an 'expiry' is placed on the queue.
 	 */
 	addMessageQueue: function(message,options) {


### PR DESCRIPTION
I ran into some trouble with browsers (Chrome & Safari) complaining about size attribute being invalid. My fix was to rename the property to inputSize, so as to avoid conflating bootstrap styling size with native input size.
